### PR TITLE
add dateutils and use it in next-date func for linux

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,2 @@
 FROM agbell/blog-base-image:latest
+RUN apt-get install dateutils

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,1 @@
 FROM agbell/blog-base-image:latest
-RUN apt-get install dateutils

--- a/blog/Earthfile
+++ b/blog/Earthfile
@@ -14,7 +14,7 @@ base-image:
   ARG TARGETARCH
   WORKDIR /site
   RUN apt-get update 
-  RUN apt-get install gcc cmake imagemagick gawk moreutils -y
+  RUN apt-get install gcc cmake imagemagick gawk moreutils dateutils -y
   RUN gem install bundler -v "~>1.0" && gem install bundler jekyll
   RUN apt-get install python3-matplotlib libvips-dev python3-pip npm pandoc -y
   RUN pip3 install pandocfilters python-frontmatter

--- a/util/functions
+++ b/util/functions
@@ -179,25 +179,13 @@ double-image() { # Double size of image. Using imagemagick
 
 next-date(){ # Get Next date for a post
 # Gets all Tues, Wed, Thurs dates from today that don't have posts
-
     os="$(uname -a)"
     
     if [[ "$os" == *"Linux"* ]]
     then
         today="$(date +%F)"
-        touch available-dates.txt
-        
-        for i in `seq 1 120`;
-        do
-            possible_date=$(date -d "$today $i days" +%Y-%m-%d)
-            day_of_w=$(date -d "$possible_date" +%w)
-         
-
-            if [[ $day_of_w -gt 1 && $day_of_w -lt 5 ]]
-            then
-                echo "$possible_date" >> available-dates.txt
-            fi
-        done;
+        fourmonths=$(date -d "$today 120 days" +%Y-%m-%d)
+        dateutils.dseq "$today"  "$fourmonths" --skip sat,sun,mon,fri > available-dates.txt
     else
         today=$(date -v +1d +'%Y-%m-%d')
         fourmonths="$(date -v +4m +'%Y-%m-%d')"


### PR DESCRIPTION
Looks like I had installed dateutils yesterday into the same codespace I was using this morning. It's not there on start up and needs to be installed. 

Also, to use the `alias` you need to add two lines of code 
```
shopt -s expand_aliases
alias dateseq="dateutils.dseq"
```
Which just seemed like it would be needlessly confusing. So I just repeated the line with the `dateutils.dseq`. 