### PR TITLE
Add Homebrew as an pre-requisites on mac

### DIFF
--- a/website/get-earthly.md
+++ b/website/get-earthly.md
@@ -36,7 +36,7 @@ os:
     source: source2
     content: |
       ### Pre-requisites
-
+      * [Homebrew for Mac](https://brew.sh/)
       * [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
       * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 


### PR DESCRIPTION
Simple addition to the tutorial pre-requisites for Mac.
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/13823057/189022993-0cc81a2b-0f74-4a17-a0a8-ce332b4fcd78.png">
