### PR TITLE
public-key-auth details

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -9,3 +9,6 @@
 
 # Renamed article
 /blog/dont-use-earthly /blog/repeatable-builds-every-time
+
+# public-key-auth implementation details, referenced by earthly-core cli during account registration
+/public-key-auth https://docs.earthly.dev/docs/misc/public-key-auth


### PR DESCRIPTION
This explains how earthly makes use of public-key authentication. A link to this page is provided during earthly account registration:

    Would you like to enable password-less login using public key authentication (https://earthly.dev/public-key-auth)? [Y/n]: y
    Which of the following public keys do you want to register (your private key is never sent or even read by earthly)?
    0) none
    1) ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICT++6ulFDilul2cgr2xa+O3ISAFlmBbCOI7SBeUS4kO your_email@example.com
    enter key number (1=default): 1

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>