### PR TITLE
Removing Earthly CI in favor of Cloud and setting up redirects

### DIFF
--- a/blog/_includes/nav/footer.html
+++ b/blog/_includes/nav/footer.html
@@ -9,7 +9,6 @@
                 <div class="mb-1 border-b hover:underline"><a href="/earthly-core">Earthly</a></div>
                 <div class="mb-1 border-b hover:underline"><a href="/earthly-cloud">Earthly Cloud</a></div>
                 <div class="mb-1 border-b hover:underline"><a href="/earthly-satellites">Earthly Satellites</a></div>
-                <div class="mb-1 hover:underline"><a href="/earthly-ci">Earthly CI</a></div>
             </div>
             <div class="col-span-1">
                 <div class="font-semibold mb-2">Content</div>

--- a/blog/_includes/nav/header.html
+++ b/blog/_includes/nav/header.html
@@ -52,7 +52,6 @@
                     <div class="pl-7 pr-8 hover:bg-[#f1fbff]"><a href="/earthly-core" class="border-b py-3 flex items-center text-sm xl:text-base">Earthly</a></div>
                     <div class="pl-7 pr-8 hover:bg-[#f1fbff]"><a href="/earthly-cloud" class="border-b py-3 flex items-center text-sm xl:text-base">Earthly Cloud</a></div>
                     <div class="ml-7 pl-[18px] pr-8 hover:bg-[#f1fbff]"><a href="/earthly-satellites" class="border-b py-3 flex items-center text-sm xl:text-base">Earthly Satellites</a></div>
-                    <div class="ml-7 pl-[18px] pr-8 hover:bg-[#f1fbff]"><a href="/earthly-ci" class="py-3 flex items-center text-sm xl:text-base">Earthly CI</a></div>
                   </div>
 
                   <div>

--- a/blog/_posts/2023-02-23-launching-earthly-CI.md
+++ b/blog/_posts/2023-02-23-launching-earthly-CI.md
@@ -10,7 +10,9 @@ excerpt: |
     Earthly CI is revolutionizing the world of CI/CD with its fast and efficient platform. Say goodbye to slow builds, complex pipelines, and outdated approaches. With Earthly CI, you can experience dramatic improvements in build times, simplified pipeline maintenance, and seamless integration with monorepos. Get started today and join the next generation of software development.
 ---
 
-*Hello world! We have partnered up with some [cool people in Silicon Valley](/blog/new-fundings-at-earthly/) [^1] to fix the world of CI. So today we are launching [Earthly CI](https://earthly.dev/signup/earthly-ci), the world's first CI/CD solution that merges together a CI and a build system. A more fine-grained understanding of the build allows Earthly CI to run faster than a CI ever could before. And it's not an incremental improvement. It's a dramatic improvement. We're talking 100% to 2,000% faster. Here's how we did it.*
+**Update: This is a historical announcement. The problems highlighted in this article are now solved by [Earthly Cloud](/). Earthly CI has been deprecated.**
+
+*Hello world! We have partnered up with some [cool people in Silicon Valley](/blog/new-fundings-at-earthly/) [^1] to fix the world of software builds. So today we are launching [Earthly CI](https://earthly.dev/signup/earthly-ci), the world's first CI/CD solution that merges together a CI and a build system. A more fine-grained understanding of the build allows Earthly CI to run faster than a CI ever could before. And it's not an incremental improvement. It's a dramatic improvement. We're talking 100% to 2,000% faster. Here's how we did it.*
 
 ## But Why??
 

--- a/blog/_posts/2023-02-23-new-fundings-at-earthly.md
+++ b/blog/_posts/2023-02-23-new-fundings-at-earthly.md
@@ -16,8 +16,8 @@ Today, we are announcing Earthly's $6.5M Seed+ funding, taking our total capital
 
 Earthly's complete set of investors includes founders of companies such as Cockroach Labs, DigitalOcean, Mesosphere, DataDog, Sentry, and Instana, as well as creators and maintainers of notable developer platforms, such as Docker, Elixir, VS Code, GitHub Copilot, Hashicorp, Envoy proxy, Cypress, Mesos, and others.
 
-The new funding will be used to improve and add more enterprise-friendly features to [Earthly CI](/blog/launching-earthly-CI/). Earthly CI is a fast, repeatable CI/CD platform that is super simple to use. It gives teams repeatable CI pipelines that you write once and run anywhere; has an automatic and instantly available build cache that makes builds faster; and it's incredibly user-friendly.
+The new funding will be used to improve and add more enterprise-friendly features to [Earthly Cloud](/). Earthly Cloud is a fast, repeatable build platform that is super simple to use. It gives teams repeatable CI pipelines that you write once and run anywhere; has an automatic and instantly available build cache that makes builds faster; and it's incredibly user-friendly.
 
-If you're a developer and this is interesting to you, [get started with Earthly CI](https://earthly.dev/signup/earthly-ci)! Let's build the next generation of software together!
+If you're a developer and this is interesting to you, [get started with Earthly Cloud](https://earthly.dev/)! Let's build the next generation of software together!
 
 {% include_html cta/bottom-cta.html %}

--- a/blog/_posts/2023-03-07-remote-code-execution.md
+++ b/blog/_posts/2023-03-07-remote-code-execution.md
@@ -13,7 +13,7 @@ funnel: 2
 excerpt: |
     Learn how Earthly Compute, a remote code execution as a service, was built to handle bursty workloads and provide secure and fast remote execution for Earthly Satellites and Earthly CI. Discover the challenges faced and the optimizations made to save compute time and improve efficiency.
 ---
-_Earthly Compute is an internal service that customers use indirectly via [Earthly Satellites](https://earthly.dev/earthly-satellites) and [Earthly CI](https://earthly.dev/earthly-ci). Now that both Satellites and CI have been publicly announced, we have some stuff ~~to get off their chests~~ that we can finally share._
+_Earthly Compute is an internal service that customers use indirectly via [Earthly Satellites](https://earthly.dev/earthly-satellites). Now that Satellites been publicly announced, we have some stuff ~~to get off their chests~~ that we can finally share._
 
 _Compared to our previous experiences, Earthly Compute was a quirky service to build. Nevertheless, we learned some things and made some mistakes, and in this write-up, we'll share how it went._[^1]
 

--- a/blog/_posts/2023-07-07-earthly-github-actions.md
+++ b/blog/_posts/2023-07-07-earthly-github-actions.md
@@ -279,7 +279,7 @@ Developer speed is also an important dimension to consider. As I mentioned earli
 
 ### **Earthly**
 
-With Earthly, executing the same pipeline locally completes in 7 seconds consistently. With [](https://earthly.dev/earthly-ci)[Earthly Satellites](https://earthly.dev/earthly-satellites) (our managed remote build runners), it also completes in 7 seconds. This is another data point that speaks to the reproducibility and consistency that Earthly offers.
+With Earthly, executing the same pipeline locally completes in 7 seconds consistently. With [Earthly Satellites](https://earthly.dev/earthly-satellites) (our managed remote build runners), it also completes in 7 seconds. This is another data point that speaks to the reproducibility and consistency that Earthly offers.
 
 <div class="wide">
 ![7-secs]({{site.images}}{{page.slug}}/7-secs.png)\

--- a/blog/_posts/2023-08-01-earthly-cloud-free-tier-launch.md
+++ b/blog/_posts/2023-08-01-earthly-cloud-free-tier-launch.md
@@ -73,9 +73,7 @@ Developer Experience isn't a nice-to-have. Done right, it becomes a critical str
 
 I'm here to tell you that CI/CD needs rethinking. Its lack of innovation over the last decade, the inaccessibility of modern build systems, and the recent and needed emphasis on Developer Experience are all blaring, screaming signals that the way we CI/CD right now isn't going to last much longer. There will be a category-defining product (or products) that will change the way we do CI/CD across big and small companies.
 
-We believe that everyone should have access to this – CI/CD that is modern like a build system, accessible like a SaaS tool, and that makes developers more productive. For this reason, we are announcing our newest offering, [Earthly Cloud](https://earthly.dev/earthly-cloud). Earthly Cloud is a SaaS build automation platform that gives you consistent builds, ridiculous speed, a next-gen developer experience, and it works with any CI (or as a standalone CI).
-
-Earthly Cloud includes the functionality of both [Earthly Satellites](https://earthly.dev/earthly-satellites) and [Earthly CI](https://earthly.dev/earthly-ci) in one package. Earthly Satellites are remote build runners that make builds fast, are super simple to use, and work seamlessly with any CI (and with your laptop). Earthly CI is a full-fledged CI system that uses Earthly Satellites under the hood.
+We believe that everyone should have access to this – CI/CD that is modern like a build system, accessible like a SaaS tool, and that makes developers more productive. For this reason, we are announcing our newest offering, [Earthly Cloud](https://earthly.dev/earthly-cloud). Earthly Cloud is a SaaS build automation platform that gives you consistent builds, ridiculous speed, a next-gen developer experience, and it works with any CI.
 
 ## Get Started With Earthly Cloud for Free
 

--- a/website/_redirects
+++ b/website/_redirects
@@ -7,6 +7,10 @@
 # Hiring
 /hiring https://jobs.earthly.dev
 
+# Redirect for CI
+/signup/earthly-ci /
+/earthly-ci /
+
 # Renamed article
 /blog/dont-use-earthly /blog/repeatable-builds-every-time
 /blog/how-cls-obj-work-python /blog/python-classes-and-objects


### PR DESCRIPTION
Articles besides "Launching-earthly-CI" have been changed to mention cloud. CI article left as is with a note at the top. Can link to de-launch post when it exists. 