### PR TITLE
Remove SOC 2 Type II From Security Page

### DIFF
--- a/website/security.html
+++ b/website/security.html
@@ -31,8 +31,7 @@ layout: default
                 We have an Information Security Program in place that is communicated throughout the organization. Our
                 Information Security Program follows the criteria set forth by the SOC 2 Framework. SOC 2 is a widely
                 known information security auditing procedure created by the American Institute of Certified Public
-                Accountants. We achieved SOC 2 Type I compliance on March 29, 2023, and SOC 2 Type II 
-                compliance on October 26, 2023.
+                Accountants. We achieved SOC 2 Type I compliance on March 29, 2023.
               </div>
               <div class="pt-5">
                 <a href="https://www.aicpa.org/soc4so" title="System and Organization Controls: SOC Suite of Services">

--- a/website/security.html
+++ b/website/security.html
@@ -33,11 +33,6 @@ layout: default
                 known information security auditing procedure created by the American Institute of Certified Public
                 Accountants. We achieved SOC 2 Type I compliance on March 29, 2023.
               </div>
-              <div class="pt-5">
-                <a href="https://www.aicpa.org/soc4so" title="System and Organization Controls: SOC Suite of Services">
-                  <img src="./assets/img/soc-logo.png" alt="SOC logo" class="h-20 mx-auto" />
-                </a>
-              </div>
             </div>
             <div class="pt-5  px-8 border-2 rounded-xl shadow-md lg:pb-20">
               <div class="flex pb-5 text-xl font-semibold">


### PR DESCRIPTION
We want to remove SOC 2 Type II because it's no longer valid since we pivoted to Lunar.